### PR TITLE
python 2.6 support

### DIFF
--- a/review/forms.py
+++ b/review/forms.py
@@ -13,7 +13,7 @@ class ReviewForm(forms.ModelForm):
         super(ReviewForm, self).__init__(*args, **kwargs)
         # Dynamically add fields for each rating category
         for category in RatingCategory.objects.all():
-            self.fields['category_{}'.format(category.pk)] = forms.ChoiceField(
+            self.fields['category_{0}'.format(category.pk)] = forms.ChoiceField(
                 choices=getattr(settings, 'REVIEW_RATING_CHOICES',
                                 Rating.rating_choices),
                 label=category.get_translation().name,
@@ -21,7 +21,7 @@ class ReviewForm(forms.ModelForm):
             if self.instance.pk:
                 try:
                     self.initial.update({
-                        'category_{}'.format(category.pk): Rating.objects.get(
+                        'category_{0}'.format(category.pk): Rating.objects.get(
                             review=self.instance, category=category).value,
                     })
                 except Rating.DoesNotExist:

--- a/review/models.py
+++ b/review/models.py
@@ -68,7 +68,7 @@ class Review(models.Model):
         ordering = ['-creation_date']
 
     def __unicode__(self):
-        return '{} - {}'.format(self.reviewed_item, self.get_user())
+        return '{0} - {1}'.format(self.reviewed_item, self.get_user())
 
     # TODO: Add magic to get ReviewExtraInfo content objects here
 
@@ -151,7 +151,7 @@ class ReviewExtraInfo(models.Model):
         ordering = ['type']
 
     def __unicode__(self):
-        return '{} - {}'.format(self.review, self.type)
+        return '{0} - {1}'.format(self.review, self.type)
 
 
 class RatingCategory(SimpleTranslationMixin, models.Model):
@@ -226,4 +226,4 @@ class Rating(models.Model):
         ordering = ['category', 'review']
 
     def __unicode__(self):
-        return '{}/{} - {}'.format(self.category, self.review, self.value)
+        return '{0}/{1} - {2}'.format(self.category, self.review, self.value)

--- a/review/tests/forms_tests.py
+++ b/review/tests/forms_tests.py
@@ -20,7 +20,7 @@ class ReviewFormTestCase(TestCase):
         form = ReviewForm(reviewed_item=self.content_object)
         self.assertTrue(form, msg=('Form has been initiated.'))
 
-        data = {'category_{}'.format(self.rating_category.pk): '3'}
+        data = {'category_{0}'.format(self.rating_category.pk): '3'}
         form = ReviewForm(reviewed_item=self.content_object, data=data)
         self.assertTrue(form.is_valid(), msg=('Form should be valid.'))
 
@@ -53,8 +53,8 @@ class ReviewFormTestCase(TestCase):
         self.new_category = RatingCategoryFactory()
         form = ReviewForm(instance=review, reviewed_item=self.content_object)
         self.assertEqual(
-            form.initial.get('category_{}'.format(self.rating_category.pk)),
+            form.initial.get('category_{0}'.format(self.rating_category.pk)),
             '3', msg=('The form\'s initial should contain the ratings.'))
         self.assertFalse(
-            form.initial.get('category_{}'.format(self.new_category.pk)),
+            form.initial.get('category_{0}'.format(self.new_category.pk)),
             msg=('The form\'s initial should not contain a new category.'))


### PR DESCRIPTION
Hello. I've tried to use your module with python 2.6, and it was not working becouse of "{}" used for format() instead of {0} {1} ...

So i fixed this. Here is a patch.
