### PR TITLE
support for custom auth model, django => 1.5

### DIFF
--- a/review/models.py
+++ b/review/models.py
@@ -42,7 +42,7 @@ class Review(models.Model):
     reviewed_item = generic.GenericForeignKey('content_type', 'object_id')
 
     user = models.ForeignKey(
-        'auth.User',
+        getattr(settings, 'AUTH_USER_MODEL', 'auth.User'),
         verbose_name=_('User'),
         blank=True, null=True,
     )


### PR DESCRIPTION
Falls back to 'auth.user' unless custom model is defined in settings.

```
modified:   models.py
```
